### PR TITLE
Removed link to Ecosystem in navigation.

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,7 +5,6 @@
       <a href="https://github.com/rails/rails/issues">Bugs/Patches</a> |
       <a href="http://rubyonrails.org/screencasts/">Screencasts</a> |
       <a href="http://rubyonrails.org/documentation/">Documentation</a> |
-      <a href="http://rubyonrails.org/ecosystem/">Ecosystem</a> |
       <a href="http://rubyonrails.org/community/">Community</a> |
       <a href="/">Blog</a>
     </nav></div>


### PR DESCRIPTION
The Ecosystem page renders 404 Not Found. Removing it from the navigation.
