### PR TITLE
Add script to import "This Week in Rails" newsletter

### DIFF
--- a/_import-this-week-in-rails.rb
+++ b/_import-this-week-in-rails.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+#
+# Import "This Week in Rails" issue to a blog post
+#
+# Usage:
+#
+# _import-this-week-in-rails.rb PUBLIC_PAGE_URL
+#
+# Example:
+#
+# _import-this-week-in-rails.rb http://us3.campaign-archive2.com/?u=2721e27ce456363785acc5405&id=5aed0d5741
+#
+
+url = ARGV[0]
+
+if url.nil?
+  puts "Usage:
+  _import-this-week-in-rails.rb PUBLIC_PAGE_URL
+
+Example:
+  _import-this-week-in-rails.rb http://us3.campaign-archive2.com/?u=2721e27ce456363785acc5405&id=5aed0d5741
+"
+  exit -1
+end
+
+require 'open-uri'
+require 'reverse_markdown'
+
+mailchimp_html = open(url).read
+
+title = Nokogiri.parse(mailchimp_html).xpath("//meta[@property='og:title']/@content").map(&:value).join
+raise "Failed to extract title" if title.empty?
+
+newsletter_html = Nokogiri.parse(mailchimp_html).at_css("table.body")
+raise "Failed to extract newsletter content" if newsletter_html.nil?
+
+tags = %w(h1 h2 h3 h4 p)
+xpath_query = tags.map { |tag| "//#{tag}" }.join ' | '
+simple_newsletter_html = newsletter_html.xpath(xpath_query).to_html
+md = ReverseMarkdown.convert(simple_newsletter_html, unknown_tags: :bypass)
+raise "Failed to convert newsletter content to markdown" if md.empty?
+
+# remove goodbits ad ("Try Goodbits for free!")
+md.gsub!(/^.*Goodbits.*$/, '')
+
+date = Time.now
+
+meta = %|---
+layout: post
+title: "#{title}"
+categories: news
+author: chancancode
+published: true
+date: #{date.to_s}
+---
+
+|
+
+post_content = meta + md
+post_path = "_posts/#{date.strftime('%Y-%m-%d')}-#{title.gsub(/[^A-Za-z0-9 ]/, '').gsub(/\s+/, '-')}.markdown"
+
+File.open(post_path, 'w') do |f|
+  f.write post_content
+end
+
+system "#{ENV['EDITOR'] || 'open'} #{post_path}"


### PR DESCRIPTION
Here is a script to import [This Week in Rails](http://rails-weekly.goodbits.io/archive/) into the weblog. Give it the url of a newsletter and it generates a blog post in markdown format.

It requires the gem reverse_markdown. I did not want to make this a dependency of the weblog so you'll have to `gem install reverse_markdown`.

Have a look at the [markdown](https://gist.github.com/pcreux/7aaea9b96396ae30e8c3) output.

Here is the result for the latest issue of This Week in Rails:

![this-week-in-rails](https://cloud.githubusercontent.com/assets/45299/5688284/2476e0d8-980a-11e4-9cb0-0e55acc6884c.png)
