### PR TITLE
Enable the no_intra_emphasis render option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ exclude:
   - CNAME
 permalink: "/:year/:i_month/:i_day/:title/"
 markdown: redcarpet
+redcarpet:
+  extensions: ["no_intra_emphasis"]
 category_dir: ""
 category_title_prefix: ""
 disqus:


### PR DESCRIPTION
Hello,

This is just a tiny pull request that enables the `:no_intra_emphasis` option rendering blog posts to avoid considering "code snippets" with several underscores as emphasis. This kind of address https://github.com/rails/weblog/pull/23#issuecomment-69466653 but this is actually not a problem if the text is surrounded by back-ticks.

Have a nice day.
