### PR TITLE
Fix Ruby5 links

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,7 @@
           <div id="podcasts" class="section"><section>
             <h3>Podcast</h3>
             <ul class="list">
-              <li><a href="http://ruby5.envylabs.com/" title="Ruby5 - The latest news in the Ruby and Rails community">Ruby5 Podcast</a></li>
+              <li><a href="http://ruby5.codeschool.com/" title="Ruby5 - The latest news in the Ruby and Rails community">Ruby5 Podcast</a></li>
             </ul>
           </section></div>
           <div id="categories" class="section"><section>

--- a/_posts/2009-08-13-what-s-new-in-edge-rails-the-bugmash-edition.markdown
+++ b/_posts/2009-08-13-what-s-new-in-edge-rails-the-bugmash-edition.markdown
@@ -81,6 +81,6 @@ I know that in the RailsEnvy podcast I jabbed a few ribs about the amount of tim
 
 I'm sure I've left out several important and/or interesting commits this week.  So, I apologize if one of those was yours.  I, and the rest of the community, certainly appreciate the effort you all put in this weekend and Rails is certainly better for it.  So, thank you, thank you, thank you to all of you BugMashers out there.  And, if you missed out on getting your commit in this round, we're certainly ready to welcome you into the next.
 
-If you prefer to have a shorter audio summary of this content, you should check out a new podcast just launched by Envy Labs, called [Ruby5](http://ruby5.envylabs.com/); a 5 minute, twice-weekly podcast covering Ruby and Ruby on Rails news.
+If you prefer to have a shorter audio summary of this content, you should check out a new podcast just launched by Envy Labs, called [Ruby5](http://ruby5.codeschool.com/); a 5 minute, twice-weekly podcast covering Ruby and Ruby on Rails news.
 
 <small>Photo: <a href="http://www.flickr.com/photos/3336/157412508/">Brooklyn Bridge Virtual Tour</a> by Diego_3336</small>

--- a/_posts/2009-10-12-what-s-new-in-edge-rails.markdown
+++ b/_posts/2009-10-12-what-s-new-in-edge-rails.markdown
@@ -52,7 +52,7 @@ Building or creating an object through a `has_one` association that contains con
     class Blog
       has_author :commit_author, :class_name => 'Author', :conditions => {:name => "Luciano Panaro"}
     end
-    
+
     @blog.build_commit_author
     # => #<Author name: "Luciano Panaro" ... >
 
@@ -71,6 +71,6 @@ Josh Peek has [relocated global exception handling](http://github.com/rails/rail
 And finally, Yehuda Katz and Carl Lerche began work on a [Rails::Application](http://github.com/rails/rails/commit/4129449594ad3d8ff2f8fb4836104f25406a104f) object to better encapsulate some of the application start up and configuration details. Also, a good bit of [initialization](http://github.com/rails/rails/commit/992c2db76cd6cd6aa9a6ba3711a6ea1ad8910062) has now gone on to move into this new object.
 
 
-Remember, if you prefer to have a shorter audio summary of some of this content and more, you should check out the <a href="http://ruby5.envylabs.com/">Ruby5 podcast</a> over at Envy Labs; it's released every Tuesday and Friday with the latest news in the Ruby and Rails community.
+Remember, if you prefer to have a shorter audio summary of some of this content and more, you should check out the <a href="http://ruby5.codeschool.com/">Ruby5 podcast</a> over at Envy Labs; it's released every Tuesday and Friday with the latest news in the Ruby and Rails community.
 
 <small>Photo: <a href="http://www.flickr.com/photos/briantaylor/357204888">Clock Tower</a> by Brian Taylor</small>

--- a/_posts/2010-05-03-community-highlights.textile
+++ b/_posts/2010-05-03-community-highlights.textile
@@ -9,13 +9,13 @@ date: 2010-05-03 16:10:00.000000000 +01:00
 ---
 <img src="/assets/2008/10/10/BlueSky.png" />
 
-It's that time again, to summarize a few interesting Rails links to highlight some of the best of the community.  All of these were initially covered on the "Ruby5 Podcast":http://ruby5.envylabs.com, the twice weekly Ruby newscast.
+It's that time again, to summarize a few interesting Rails links to highlight some of the best of the community.  All of these were initially covered on the "Ruby5 Podcast":http://ruby5.codeschool.com, the twice weekly Ruby newscast.
 
 *Rails 3 Content*
 
-The next "Rails3 Bugmash":http://railsbridge.org/news_items/12 is taking place May 15th and 16th.  If you've never contributed to Rails, this is your chance to give back a little and do your part to make Rails 3 the best version ever.  
+The next "Rails3 Bugmash":http://railsbridge.org/news_items/12 is taking place May 15th and 16th.  If you've never contributed to Rails, this is your chance to give back a little and do your part to make Rails 3 the best version ever.
 
-To get a complete picture of routes in Rails 3, Rizwan Reza "covered it best":http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/ in an article over on the Engine Yard blog.  If you dig the Engine Yard Rails 3 content, they recently created "Rails Dispatch":http://www.railsdispatch.com, where they have articles and screencasts published weekly. 
+To get a complete picture of routes in Rails 3, Rizwan Reza "covered it best":http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/ in an article over on the Engine Yard blog.  If you dig the Engine Yard Rails 3 content, they recently created "Rails Dispatch":http://www.railsdispatch.com, where they have articles and screencasts published weekly.
 
 Alex Maccaw recently used the Rails 3 ActiveModel abstraction to build an ActiveRecord-like in-memory database called "Supermodel":http://github.com/maccman/supermodel. You get all of the ActiveRecord goodness, such as validations, callbacks, and observers, but with none of that database headache.
 
@@ -27,19 +27,19 @@ Lastly, if it's still not clear to you how awesome bundler is, go read "Yehuda's
 
 <img src="/assets/2009/9/1/camera.jpg" />
 
-Do you ever find the need to access _current_user_ in your models?  This is often required when you're logging model/table changes on a per user basis.  There are many hacks to accomplish this, but David Bock has a gem called "SentientUser":http://github.com/bokmann/sentient_user which does this a little cleaner.  
+Do you ever find the need to access _current_user_ in your models?  This is often required when you're logging model/table changes on a per user basis.  There are many hacks to accomplish this, but David Bock has a gem called "SentientUser":http://github.com/bokmann/sentient_user which does this a little cleaner.
 
-Once your websites goes big and you start to worry about malicious user attacks, you may want to take a look at Arto Bendiken and Brendon Murphy's "Rack::Throttle Middleware":http://datagraph.rubyforge.org/rack-throttle/.  Throttle does just want you think it does, allowing you to limit the number of requests a user can ping your site (per second).  
+Once your websites goes big and you start to worry about malicious user attacks, you may want to take a look at Arto Bendiken and Brendon Murphy's "Rack::Throttle Middleware":http://datagraph.rubyforge.org/rack-throttle/.  Throttle does just want you think it does, allowing you to limit the number of requests a user can ping your site (per second).
 
-Lastly, Ryan Bates released version 1.1 of "CanCan":http://wiki.github.com/ryanb/cancan/upgrading-to-11, his authorization and permission library that allows you to restrict what your users can do throughout your application.  
+Lastly, Ryan Bates released version 1.1 of "CanCan":http://wiki.github.com/ryanb/cancan/upgrading-to-11, his authorization and permission library that allows you to restrict what your users can do throughout your application.
 
 *Service Libraries*
 
 <img src="/assets/2008/10/10/libraries.png" />
 
-You may have heard that the Facbook API is now adopting OAuth2.  If you're ready to jump in, Michael Bleigh released the "OAuth2 gem":http://intridea.com/2010/4/22/oauth2-gem-just-in-time-for-facebook-graph just last week.  
+You may have heard that the Facbook API is now adopting OAuth2.  If you're ready to jump in, Michael Bleigh released the "OAuth2 gem":http://intridea.com/2010/4/22/oauth2-gem-just-in-time-for-facebook-graph just last week.
 
-Rails makes a great RESTful backend for iPhone applications, and recently Anthony Moralez created "APN_on_rails":http://github.com/PRX/apn_on_rails which makes it super easy to do Apple Push Notifications.  
+Rails makes a great RESTful backend for iPhone applications, and recently Anthony Moralez created "APN_on_rails":http://github.com/PRX/apn_on_rails which makes it super easy to do Apple Push Notifications.
 
 There's no need to reinvent the wheel if your Rails application needs e-commerce, this is where the "Spree gem":http://spreecommerce.com/blog/2010/03/13/spree-0100-released/ comes in, which recently hit version 0.10.0, containing a bunch of new features.
 
@@ -47,17 +47,17 @@ There's no need to reinvent the wheel if your Rails application needs e-commerce
 
 <img src="/assets/2008/10/10/performance.png" />
 
-Does your Rails application have a monster testing library that takes forever to run?  Then it may be time to take a look at "Hydra":http://github.com/ngauthier/hydra by Nick Gauthier, a distributed testing framework which allows you to run your tests in parallel locally or across remote servers.  
+Does your Rails application have a monster testing library that takes forever to run?  Then it may be time to take a look at "Hydra":http://github.com/ngauthier/hydra by Nick Gauthier, a distributed testing framework which allows you to run your tests in parallel locally or across remote servers.
 
-Some people think cucumber can be too verbose for integration tests (which clients may never read).  If you think cucumber is for vegetarians, then perhaps it's time to taste some "Steak":http://github.com/cavalle/steak by Luismi Cavalle.  Steak is a small library which helps you generate quick and clean acceptance/integration tests using RSpec.  
+Some people think cucumber can be too verbose for integration tests (which clients may never read).  If you think cucumber is for vegetarians, then perhaps it's time to taste some "Steak":http://github.com/cavalle/steak by Luismi Cavalle.  Steak is a small library which helps you generate quick and clean acceptance/integration tests using RSpec.
 
 Talking about RSpec, there are some new conventions out there to clean up your old RSpec code.  If you haven't started using "Let", then it may be time to look through a few of "Jon Larkowski's slides":http://pure-rspec-rubynation.heroku.com/.
 
 *Additional Useful Libraries*
 
-If you ever find yourself with odd memory issues then it's probably time to use "memprof.com":http://memprof.com/, a new web service by Joe Damato and Ruby Hero Aman Gupta.  Memprof allows you to collect memory usage information from a Ruby process and immediately upload and view it using an intuitive web interface.  
+If you ever find yourself with odd memory issues then it's probably time to use "memprof.com":http://memprof.com/, a new web service by Joe Damato and Ruby Hero Aman Gupta.  Memprof allows you to collect memory usage information from a Ruby process and immediately upload and view it using an intuitive web interface.
 
-Rails applications are often full of forms, and sometimes you even need to give your clients the ability to create different types of forms or surveys.  This is where the "Census gem":http://blog.envylabs.com/2010/04/census-rails-demographics-collection/ comes in, providing an admin interface for creating forms, and even the ability to search through the results.  
+Rails applications are often full of forms, and sometimes you even need to give your clients the ability to create different types of forms or surveys.  This is where the "Census gem":http://blog.envylabs.com/2010/04/census-rails-demographics-collection/ comes in, providing an admin interface for creating forms, and even the ability to search through the results.
 
 To wrap things up, "delayed_job":http://opensoul.org/2010/4/3/delayed_job-2-0 recently hit 2.0, and you'll want to upgrade if you have an older version.  The new version has some performance improvements and adds support for non-ActiveRecord ORMs.
 
@@ -67,7 +67,7 @@ To wrap things up, "delayed_job":http://opensoul.org/2010/4/3/delayed_job-2-0 re
 
 To keep track of Ruby conferences check out "Ruby There":http://www.rubythere.com, a listing of all the upcoming conferences and even when the Call for Proposals are due.
 
-For more news and libraries check out the "Ruby5 podcast":http://ruby5.envylabs.com.  If you don't usually listen to audio, you can just subscribe to the "RSS feed":http://feeds.feedburner.com/Ruby5 which contains a summary of everything covered.  
+For more news and libraries check out the "Ruby5 podcast":http://ruby5.envylabs.com.  If you don't usually listen to audio, you can just subscribe to the "RSS feed":http://feeds.feedburner.com/Ruby5 which contains a summary of everything covered.
 
 If you have any stories/libraries you'd like to spread the word about, feel free to email ruby5@envylabs.com and we'll at least get you covered on the podcast. Thanks!
 

--- a/_posts/2010-08-28-rails-has-great-documentation.textile
+++ b/_posts/2010-08-28-rails-has-great-documentation.textile
@@ -35,7 +35,7 @@ There's also a few good free screencasts over on <a href="http://teachmetocode.c
 
 *Keeping on the Edge*
 
-If you find yourself wondering how to keep up with all of the newest features / libraries for Rails 3, both the <a href="http://ruby5.envylabs.com">Ruby5 Podcast</a> and the <a href="http://rubyshow.com">Ruby Show</a> are going strong.  Don't listen to audio? It doesn't matter, just subscribe to the <a href="http://feeds.feedburner.com/Ruby5">Ruby5 RSS feed</a> and get links with descriptions to all the newest libraries, tutorials, and more.  You might also want to checkout Peter Cooper's new <a href="http://rubyweekly.com/">Ruby Weekly</a>, a Ruby email newsletter</a>.
+If you find yourself wondering how to keep up with all of the newest features / libraries for Rails 3, both the <a href="http://ruby5.codeschool.com">Ruby5 Podcast</a> and the <a href="http://rubyshow.com">Ruby Show</a> are going strong.  Don't listen to audio? It doesn't matter, just subscribe to the <a href="http://feeds.feedburner.com/Ruby5">Ruby5 RSS feed</a> and get links with descriptions to all the newest libraries, tutorials, and more.  You might also want to checkout Peter Cooper's new <a href="http://rubyweekly.com/">Ruby Weekly</a>, a Ruby email newsletter</a>.
 
 *Need to upgrade a big app to Rails 3?*
 


### PR DESCRIPTION
Ruby5 is no longer hosted on envylabs.com, so I changed all the links
to ruby5.codeschool.com since it was mentioned in several places and a
few listeners sent us heads up.
