### PR TITLE
Add category to 2016-01-25 post

### DIFF
--- a/_posts/2016-01-25-Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released.markdown
+++ b/_posts/2016-01-25-Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Rails 5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1, and rails-html-sanitizer 1.0.3 have been released!'
-categories:
+categories: releases
 author: tenderlove
 published: true
 date: 2016-01-25 11:52:43 -08:00


### PR DESCRIPTION
[This recent post](http://weblog.rubyonrails.org/2016/1/25/Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released/) does not have the `releases` category specified so the post does not appear under the [releases](http://weblog.rubyonrails.org/releases/) category.

This PR fixes that.
