### PR TITLE
Tweak link styles

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
   <nav>
-    <a href="http://rubyonrails.org"><img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails" /></a>
+    <a id='rails-logo' href="http://rubyonrails.org"><img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails" /></a>
 
     <ul>
       <li class="first"><a href="/">Everything</a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
   <nav>
-    <a id='rails-logo' href="http://rubyonrails.org"><img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails" /></a>
+    <a id="rails-logo" href="http://rubyonrails.org"><img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails" /></a>
 
     <ul>
       <li class="first"><a href="/">Everything</a></li>

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@ body {
 }
 
 a { color: #cc0000; text-decoration: none; }
-a:hover { padding-bottom: 2px; border-bottom: 2px solid #cc0000; }
+a:hover { text-decoration: underline; }
 
 h2 {
   font-size: 1.4rem;
@@ -157,7 +157,6 @@ a#rails-logo:hover { border-bottom: none; opacity: 0.7; }
 }
 
 .entry-title a { color: black; }
-.entry-title a:hover { border-bottom: 3px solid #000; padding-bottom: 0px; }
 
 .entry-meta {
 	color: #777;

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@ body {
 }
 
 a { color: #cc0000; text-decoration: none; }
-a:hover { text-decoration: underline; }
+a:hover { padding-bottom: 2px; border-bottom: 2px solid #cc0000; }
 
 h2 {
   font-size: 1.4rem;
@@ -69,8 +69,9 @@ nav {
 nav ul { margin: 1rem 0 0; padding: 0; float: right; font-size: 14px; }
 nav ul li { display: inline; list-style-type: none; margin-left: 30px; }
 nav ul li.first { margin-left: 5px; }
-nav ul li a { font-weight: bold; border-bottom: 2px solid #ff9999; }
-nav ul li a:hover { color: #000; border-bottom: 2px solid #cc0000; text-decoration: none; }
+nav ul li a { padding-bottom: 1px; font-weight: bold; border-bottom: 2px solid #cc0000; }
+nav ul li a:hover { padding-bottom: 1px ;color: #000; border-bottom: 2px solid #000; text-decoration: none; }
+a#rails-logo:hover { border-bottom: none; opacity: 0.7; }
 
 /* Layout */
 #wrapper {
@@ -152,11 +153,11 @@ nav ul li a:hover { color: #000; border-bottom: 2px solid #cc0000; text-decorati
 	font-weight: normal;
   line-height: 2.5rem;
   font-size: 2.2rem;
-  color: black;
   margin-bottom: 0;
 }
 
 .entry-title a { color: black; }
+.entry-title a:hover { color: black; border-bottom: 3px solid #000; padding-bottom: 0px; }
 
 .entry-meta {
 	color: #777;

--- a/styles.css
+++ b/styles.css
@@ -157,7 +157,7 @@ a#rails-logo:hover { border-bottom: none; opacity: 0.7; }
 }
 
 .entry-title a { color: black; }
-.entry-title a:hover { color: black; border-bottom: 3px solid #000; padding-bottom: 0px; }
+.entry-title a:hover { border-bottom: 3px solid #000; padding-bottom: 0px; }
 
 .entry-meta {
 	color: #777;


### PR DESCRIPTION
Adjust links styles to tweaks on rubyonrails.org
# Logo:

<img width="207" alt="screen shot 2016-08-23 at 7 49 34 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905624/fe606742-6973-11e6-87a6-0abfc12e51e9.png">
# Logo on hover:

<img width="198" alt="screen shot 2016-08-23 at 7 49 46 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905664/2149bac4-6974-11e6-91fd-43ca0c8419fa.png">
# Text links before:

<img width="709" alt="screen shot 2016-08-23 at 8 06 41 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905862/054f3294-6975-11e6-8bbd-80d4fbe29f69.png">
# Text links after:

<img width="718" alt="screen shot 2016-08-23 at 8 06 58 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905868/0d249630-6975-11e6-9567-8d85e061c949.png">
# Nav links before: 3 colors

<img width="740" alt="screen shot 2016-08-23 at 8 01 43 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905705/56b84248-6974-11e6-93e5-3674aee6d7b0.png">
# Nav links after: 2 colors

<img width="741" alt="screen shot 2016-08-23 at 7 00 10 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905741/76db2068-6974-11e6-9e43-b6d514badc9f.png">
# Post titles before:

<img width="730" alt="screen shot 2016-08-23 at 7 40 35 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905794/b1e14548-6974-11e6-9f9c-0c99a782122b.png">
# Post titles after:

<img width="726" alt="screen shot 2016-08-23 at 7 40 53 pm" src="https://cloud.githubusercontent.com/assets/1353214/17905807/c1cd0bcc-6974-11e6-84cd-cc6c27697b4f.png">
