### PR TITLE
Remove B/C HTML structure and improve mobile view

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,15 +3,15 @@ layout: default
 title: "Riding Rails: Not Found"
 permalink: 404.html
 ---
-<div class="hentry article"><article>
-  <div class="entry-header header"><header>
-    <h2 class="entry-title">You’ve gone off the Rails!</h2>
-  </header></div>
+<article>
+  <header>
+    <h2>You’ve gone off the Rails!</h2>
+  </header>
 
-  <div class="entry-content section"><section>
+  <section>
     <p>Sorry, we couldn’t find what you were looking for.</p>
-    <p class="back">
+    <p>
       <small><a href="/">← Back to homepage</a></small>
     </p>
-  </section></div>
-</article></div>
+  </section>
+</article>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,7 +2,7 @@
     <a id="rails-logo" href="http://rubyonrails.org"><img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails" /></a>
 
     <ul>
-      <li class="first"><a href="/">Everything</a></li>
+      <li><a href="/">Everything</a></li>
       <li><a href="/releases/">Releases</a></li>
       <li><a href="/news/">News</a></li>
     </ul>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,6 +1,6 @@
-        <div class="hentry article"><article>
-          <div class="entry-header header"><header>
-            <h2 class="entry-title">
+        <article>
+          <header>
+            <h2>
               <a href="{{ post.url }}" rel="bookmark">{{ post.title | escape }}</a>
             </h2>
             <p class="entry-meta">
@@ -18,10 +18,10 @@
                 </span>
               {% endif %}
             </p>
-          </header></div>
-          <div class="entry-content section"><section>
+          </header>
+          <section>
 <!-- Begin Post -->
 {{ post.content }}
 <!-- End Post -->
-          </section></div>
-        </article></div>
+          </section>
+        </article>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,11 @@
     <div id="wrapper">
       {% include navigation.html %}
 
-      <div id="content" class="section"><section>
+      <main>
 <!-- Begin Content -->
 {{ content }}
 <!-- End Content -->
-      </section></div>
+      </main>
     </div>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,14 +8,14 @@
   <body>
     <div id="wrapper">
       {% include navigation.html %}
-      <div id="content" class="section"><section>
+      <main>
 <!-- Begin Content -->
-        <div class="hentry article"><article>
-          <div class="entry-header header"><header>
-            <h2 class="entry-title">
+        <article>
+          <header>
+            <h2>
               <a href="{{ page.url }}" rel="bookmark">{{ page.title | escape }}</a>
             </h2>
-            <p class="entry-meta">
+            <p>
               Posted by <span class="vcard"><span class="fn">{{ page.author }}</span></span>,
               <span class="published" title="{{ page.date | date_to_xml_schema }}">{{ page.date | date: "%B %-d, %Y @ %l:%M %P" }}</span>
               {% if page.categories.size > 0 %}
@@ -30,15 +30,15 @@
               </span>
               {% endif %}
             </p>
-          </header></div>
-          <div class="entry-content section"><section>
+          </header>
+          <section>
 <!-- Begin Post -->
 {{ content }}
 <!-- End Post -->
-          </section></div>
-        </article></div>
+          </section>
+        </article>
 <!-- End Content -->
-      </section></div>
+      </main>
     </div>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,138 +1,180 @@
-/* Common Definitions */
+html {
+  font-size: 62.5%;
+}
 
 body {
+  background-color: #ffffff;
+  color: #000000;
   font-family: Georgia, serif;
-  line-height: 2rem;
-  font-size: 1.3rem;
-  background-color: white;
+  font-size: 2rem;
+  line-height: 2.8rem;
   margin: 0;
   padding: 0;
-  color: #000;
-}
-
-a { color: #cc0000; text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-h2 {
-  font-size: 1.4rem;
-  color: black;
-  margin-bottom: 0.75rem;
-}
-
-h3 {
-  font-weight: normal;
-  font-size: 1.3rem;
-  margin: 0.5rem 0 0;
-}
-
-h4 {
-  font-size: 1em;
-  font-weight: normal;
-  margin: 1.25em 0 0.25em;
-}
-
-p {
-  margin: 0 0 1em 0;
-}
-
-ul, ol {
-  margin: 0.5em 0 1em 0;
-  padding: 0 0 0 1.75em;
-}
-
-li {
-  margin: 0 0 0.5em 0;
-}
-
-pre	{
-  background-color: #eee;
-  margin: 1em 0;
-  padding: 0.5em 1em !important;
-  font-size: 0.9375em;
-  overflow: auto;
-}
-
-code {
-  font-family: Courier New, Courier, mono;
-  font-size: 0.9375em;
-  color: #666;
-}
-
-blockquote {
-  margin: 1em, 1.75em;
 }
 
 a > img {
   border: none;
 }
 
-
-/* Top Navigation */
+#wrapper {
+  margin: 0 auto 4rem;
+  max-width: 740px;
+}
 
 nav {
-  width: 700px;
-  margin: 3rem auto 1rem;
+  margin: 4rem 2rem;
   overflow: hidden;
 }
 
-nav ul { margin: 1rem 0 0; padding: 0; float: right; font-size: 14px; }
-nav ul li { display: inline; list-style-type: none; margin-left: 30px; }
-nav ul li.first { margin-left: 5px; }
-nav ul li a { padding-bottom: 1px; font-weight: bold; border-bottom: 2px solid #cc0000; }
-nav ul li a:hover { padding-bottom: 1px ;color: #000; border-bottom: 2px solid #000; text-decoration: none; }
-a#rails-logo:hover { border-bottom: none; opacity: 0.7; }
-
-
-/* Layout */
-#wrapper {
-  margin: 0 auto 2em;
-  width: 960px;
-  overflow: hidden;
+#rails-logo {
+  display: block;
+  float: left;
 }
 
-#content {
-  width: 700px;
-  margin: 19px auto 0;
-}
-
-
-/* Post */
-.hentry {
-  margin: 2rem 0 5rem;
-}
-
-.entry-header {
-  margin: 0 0 0.5em 0;
-}
-
-.entry-title {
-  font-weight: normal;
-  line-height: 2.5rem;
-  font-size: 2.2rem;
-  margin-bottom: 0;
-}
-
-.entry-title a { color: black; }
-
-.entry-meta {
-  color: #777;
-  font-size: 1rem;
-  margin: 0;
-}
-
-.entry-footer {
-  color: #413E38;
-  font-size: 1em;
-  margin: 0.5em 0 2em;
+nav ul {
+  float: right;
+  font-size: 1.4rem;
+  list-style: none;
+  margin: 2.3rem 0 0;
   padding: 0;
 }
 
+nav ul li {
+  display: inline;
+  margin: 0 0 0 3rem;
+}
 
-/* Tweets */
+nav ul li a {
+  border-bottom: 0.2rem solid #cc0000;
+  color: #cc0000;
+  font-weight: bold;
+  padding-bottom: 0.1rem;
+  text-decoration: none;
+}
 
-twitterwidget + p,
-iframe + p {
-  margin-top: 1em;
+nav ul li a:hover {
+  border-bottom: 0.2rem solid #000000;
+  color: #000000;
+}
+
+main {
+  margin: 0 2rem;
+}
+
+article {
+  margin: 2rem 0 4rem;
+}
+
+article header {
+  margin: 0 0 0.5rem 0;
+}
+
+article header h2 {
+  font-weight: normal;
+  font-size: 3.4rem;
+  line-height: 3.8rem;
+  margin-bottom: 0;
+}
+
+article header h2 a {
+  color: #000000;
+  text-decoration: none;
+}
+
+article header h2 a:hover {
+  text-decoration: underline;
+}
+
+article header p {
+  color: #777777;
+  font-size: 1.6rem;
+  margin: 0.5rem 0;
+}
+
+article header p a {
+  color: #cc0000;
+  text-decoration: none;
+}
+
+article header p a:hover {
+  text-decoration: underline;
+}
+
+article section {
+  font-size: 2rem;
+  margin: 1rem 0;
+}
+
+article section h2 {
+  font-size: 2.4rem;
+  margin: 2rem 0 1rem;
+}
+
+article section h3 {
+  font-size: 2rem;
+  font-weight: normal;
+  margin: 1rem 0 0.5rem 0;
+}
+
+article section p {
+  font-size: 2rem;
+  margin: 0 0 1.5rem 0;
+}
+
+article section ul, article section ol {
+  margin: 0.5em 0 1.5rem 0;
+  padding: 0 0 0 2.5rem;
+}
+
+article section li {
+  font-size: 2rem;
+  margin: 0 0 0.5rem 0;
+}
+
+article section a {
+  color: #cc0000;
+  text-decoration: none;
+}
+
+article section a:hover {
+  text-decoration: underline;
+}
+
+article section img {
+  max-width: 100%;
+}
+
+article section pre {
+  background-color: #eeeeee;
+  font-size: 1.5rem;
+  line-height: 2.4rem;
+  margin: 2rem 0;
+  overflow: auto;
+  padding: 1.5rem 2rem !important;
+}
+
+article section code, article section tt {
+  font-family: Courier New, Courier, mono;
+}
+
+article section p code, article section p tt {
+  color: #666666;
+  overflow: auto;
+  white-space: nowrap;
+}
+
+article section pre code {
+  color: #666666;
+  font-size: 1.5rem;
+}
+
+article section blockquote {
+  margin: 1rem 2rem;
+}
+
+article section twitterwidget + p,
+article section iframe + p {
+  margin-top: 1.5rem;
 }
 
 blockquote.twitter-tweet {
@@ -158,4 +200,100 @@ blockquote.twitter-tweet a[href^="https://twitter.com"] {
   font-weight: normal;
   color: #666;
   font-size: 12px;
+}
+
+@media only screen and (max-width: 640px) {
+  nav {
+    margin: 2rem 2rem 3rem;
+  }
+
+  nav ul li {
+    margin: 0 2rem 0 0;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  nav {
+    margin: 2rem 1.5rem 1rem;
+  }
+
+  #rails-logo {
+    float: none;
+  }
+
+  nav ul {
+    float: none;
+    margin: 1.5rem 0 0.5rem;
+  }
+
+  nav ul li {
+    margin: 0 2rem 0 0;
+  }
+
+  main {
+    margin: 0 1.5rem;
+  }
+
+  article {
+    margin: 1.5rem 0 3rem;
+  }
+
+  article header h2 {
+    font-size: 2.2rem;
+    line-height: 2.6rem;
+  }
+
+  article section {
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+  }
+
+  article section h2 {
+    font-size: 1.9rem;
+    line-height: 2.3rem;
+  }
+
+  article section h3 {
+    font-size: 1.6rem;
+    line-height: 2.1rem;
+  }
+
+  article header p {
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+    margin: 0.25rem 0;
+  }
+
+  article section p {
+    font-size: 1.6rem;
+    line-height: 2.1rem;
+    margin: 0 0 1.5rem 0;
+  }
+
+  article section ul, article section ol {
+    margin: 0.5em 0 1.5rem 0;
+    padding: 0 0 0 2.1rem;
+  }
+
+  article section li {
+    font-size: 1.6rem;
+    line-height: 2.1rem;
+  }
+
+  article section blockquote {
+    margin: 0.5rem 1.5rem;
+  }
+
+  article section pre {
+    font-size: 1.2rem;
+    line-height: 1.8rem;
+    margin: 1rem 0;
+    overflow: auto;
+    padding: 0.7rem 1rem !important;
+  }
+
+  article section pre code {
+    font-size: 1rem;
+    line-height: 1.2rem;
+  }
 }


### PR DESCRIPTION
When I first converted the blog to GitHub pages we were still supporting versions of IE that didn't understand HTML5 properly so the structure had <div> elements to provide backwards compatibility for those browsers. We're now four years on and we no longer support those browsers so tidy up the HTML and CSS.

Also as part of this the mobile view has been improved by using breakpoints to adjust font-sizing.

Old view: 
![old-mobile-view](https://cloud.githubusercontent.com/assets/6321/20280197/62a7b1f4-aaa3-11e6-91bc-4159b42642aa.png)

New view:
![new-mobile-view](https://cloud.githubusercontent.com/assets/6321/20280215/7668f5c2-aaa3-11e6-82c9-cf6037c2a5ba.png)

