### PR TITLE
Set default og:image tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,8 @@ gems:
   - jemoji
   - jekyll-redirect-from
   - jekyll-seo-tag
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: https://avatars.githubusercontent.com/u/4223


### PR DESCRIPTION
This Pull Request adds default `og:image` which is same as [rails organization](https://github.com/rails) icon image.

Ref. https://github.com/jekyll/jekyll-seo-tag#setting-a-default-image