### PR TITLE
Add a post about the Google Summer of Code 2017

### DIFF
--- a/_posts/2017-03-02-google-summer-of-code-2017.markdown
+++ b/_posts/2017-03-02-google-summer-of-code-2017.markdown
@@ -1,0 +1,71 @@
+---
+layout: post
+title: Google Summer of Code 2017
+categories: activism
+published: true
+date: 2017-03-02 21:21:00 +01:00
+author: Robin Dupret
+---
+
+We're very happy to announce that Ruby on Rails has been accepted as an
+organization for the [Google Summer of Code][gsoc] (GSoC) 2017 edition!
+
+The GSoC is a program proposed by Google that allows college students (who are at
+least 18 years old) to contribute to open source projects during the summer (from
+May 30 to August 21) and get paid for that!
+
+Rails has already participated in the past and many different projects have been
+achieved through this program and are now invaluable in the framework's ecosystem
+like the [web console][web-console], the [RubyBench][ruby-bench] site or the
+[rails-ujs][rails-ujs] project.
+
+Students need to propose an idea that will improve the project they are willing
+to work on and eventually the different steps that will be tackled to achieve
+it. Throughout the process, students are guided by one or several mentors. Mentors
+are here to make sure that students go in the right direction and help them
+if they stumble against problems.
+
+This can be a very interesting and rewarding experience for students as they can
+learn a lot from more experienced developers and it's an easy way to get involved
+in the open source world.
+
+A [list of possible ideas][ideas] is already available if you want to work on
+Ruby on Rails this summer but feel free to propose your own if you want to work
+on something different and you still think it can be valuable for the project.
+
+If you are interested in getting involved, please join the [mailing list][mailing-list]
+and let us know what you would like to work on. Thus, you can get early feedback
+and avoid going in the wrong direction or putting too much effort in a project
+that may not be accepted.
+
+Student applications will be open on March 20 and will end on April 3. Make
+sure to keep an eye on the [timeline][gsoc] if you are willing to participate
+to this program. You can find the application template on [our wiki][application].
+
+If you are not a student, you can still get involved by participating on the
+mailing list or by applying as a mentor!
+
+As a side note, a similar project is available and is aiming at getting more
+women involved in the open source world: [Rails Girls Summer of Code][rails-girls].
+Unlike GSoC, this project is exclusively about Ruby on Rails, it's not restricted
+to students and there are no age limitations. Applications are open and will close
+very soon though, on March 8.
+
+Useful resources:
+
+* [The Google Summer of Code 2017 site and timeline][gsoc]
+* [The student manual][manual]
+* [The list of possible ideas for Ruby on Rails][ideas]
+* [Our mailing list][mailing-list]
+* [Some guides on Open Source][guides]
+
+[gsoc]: https://summerofcode.withgoogle.com/
+[ideas]: https://github.com/railsgsoc/ideas/wiki/2017-Ideas
+[mailing-list]: https://groups.google.com/forum/#!forum/rubyonrails-gsoc
+[web-console]: https://github.com/rails/web-console
+[ruby-bench]: https://rubybench.org/
+[rails-ujs]: https://github.com/rails/rails-ujs
+[application]: https://github.com/railsgsoc/ideas/wiki/Ruby-on-Rails-Application-Template
+[manual]: http://write.flossmanuals.net/gsocstudentguide/what-is-google-summer-of-code/
+[guides]: https://opensource.guide/
+[rails-girls]: https://railsgirlssummerofcode.org/


### PR DESCRIPTION
Hi,

This is just a tiny pull request to add a blog post about the upcoming Google Summer of Code as we've been accepted as an organization. Also add a mention to Rails Girls Summer of Code as this may be interesting (even though applications will close pretty soon).

Let me know if there's any typo / things to improve. I don't know how mentors should apply if they want to give us some help so it's a bit unclear in the post at the moment.

Have a nice day. :-)