### PR TITLE
Remove duplicated feed link tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,width=device-width,minimum-scale=1,initial-scale=1">
-    <link rel="alternate" type="application/atom+xml" title="Atom" href="/feed/atom.xml">
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
     <link href="/print.css" type="text/css" media="print" rel="stylesheet">
     <script type="text/javascript" async="" src="http://platform.twitter.com/widgets.js"></script>


### PR DESCRIPTION
`application/atom+xml` link tag seems duplicated because of #100 . Since `feed_meta` automatically adds the tag, remove self-wrote alternate feed tag inside head.