### PR TITLE
Fix SSL warnings when visiting weblog.rubyonrails.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is the repository for the [Riding Rails][1] blog.
 
 See the gh-pages branch for the content.
 
-[1]: http://weblog.rubyonrails.org/
+[1]: https://weblog.rubyonrails.org/

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Riding Rails
+url: https://weblog.rubyonrails.org
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,6 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
     <link href="/print.css" type="text/css" media="print" rel="stylesheet">
-    <script type="text/javascript" async="" src="http://platform.twitter.com/widgets.js"></script>
+    <script type="text/javascript" async="" src="https://platform.twitter.com/widgets.js"></script>
     {% seo %}
     {% feed_meta %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: http://weblog.rubyonrails.org/sitemap.xml
+Sitemap: https://weblog.rubyonrails.org/sitemap.xml


### PR DESCRIPTION
I've added 4 separate commits, which are tangentially related, hence the single pull request. 

## Twitter widget is currently loaded from unsafe url

When I visit https://weblog.rubyonrails.org using Chrome (recent version) I see an unsafe script warning in the browser bar. Screenshots are attached.

It looks like the site (weblog.rubyonrails.org) is loading the twitter widget from  http://platform.twitter.com/widget.js when really you probably want to load from https://platform.twitter.com/widget.js.

So the first of the four commits in this pull-request (sha 9e3e7925) addresses that.

Image 1 - (below) shows the red shield icon on the right hand side of the browser bar (mouse is hovering over it and message titled 'This page is trying to load unsafe scripts from unauthorised sources'.

![weblog-unsafe-1](https://user-images.githubusercontent.com/56636/39091383-d10abef0-45ea-11e8-9928-1c4c7dbdbc50.png)

Image 2 - (below) shows what happens when you click the red shield icon (a window opens with an option to load the unsafe scripts).

![weblog-unsafe-2](https://user-images.githubusercontent.com/56636/39091384-d1338e7a-45ea-11e8-87f7-7fdbdb81c6a4.png)

Image 3 - (below) shows what happens after you click 'Load unsafe scripts' (note the 'Not secure' warning on the left hand side of the browser bar)

![weblog-unsafe-3](https://user-images.githubusercontent.com/56636/39091385-d1557756-45ea-11e8-9f6f-2202b9af5ebf.png)

Image 4 - (below) shows at least one of the culprits highlighted in Chrome inspector: 

![weblog-unsafe-4](https://user-images.githubusercontent.com/56636/39091386-d1780924-45ea-11e8-9280-4a1aca8a66fc.png)


## Readme currently links to `http://` URL
 
The README currently links to http://weblog.rubyonrails.org, so I've updated it to use the SSL variant in another commit (sha f084e4ba). It's no big deal as users are redirected to https:// anyway without this addition.


## Robots.txt currently uses `http://` URL for sitemap 

I've updated robots.txt to use the SSL variant for the sitemap too, just for consistency see sha 1bfa5cd.


## Canonical URL, atom link and OG:url currently use `http://`

The last commit (57a43cd) ensures that `https://` is used for the atom link, as well as both the og:url meta tag, and the canonical url link tag too, all of which currently point to http:// urls.

Note that jekyll ignores any url set in `_config.yml` if you are running in development, as explained here: https://github.com/jekyll/jekyll/issues/5488 
