### PR TITLE
Add pagination back

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,12 +5,17 @@ exclude:
   - Gemfile.lock
   - README.md
   - CNAME
+paginate: 10
 permalink: "/:year/:i_month/:i_day/:title/"
 markdown: kramdown
 category_dir: ""
 category_title_prefix: ""
+pagination:
+   previous: "&larr; Previous"
+   next: "Next &rarr;"
 plugins:
   - jekyll-feed
+  - jekyll-paginate
   - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-sitemap

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,0 +1,12 @@
+<nav class="pagination">
+  {% if paginator.next_page %}
+    <a href="{{ base_url }}/page{{paginator.next_page}}" class="previous">{{ site.pagination.previous }}</a>
+  {% endif %}
+  {% if paginator.previous_page %}
+    {% if paginator.previous_page == 1%}
+      <a href="{{ base_url }}/" class="next">{{ site.pagination.next }}</a>
+    {% else %}
+      <a href="{{ base_url }}/page{{paginator.previous_page}}" class="next">{{ site.pagination.next }}</a>
+    {% endif %}
+  {% endif %}
+</nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,6 +36,14 @@
 <!-- End Post -->
           </section>
         </article>
+        <nav class="pagination">
+          {% if page.previous %}
+            <a href="{{ page.previous.url }}" title="{{ page.previous.title }}" class="previous">&larr; Previous</a>
+          {% endif %}
+          {% if page.next %}
+            <a href="{{ page.next.url }}" title="{{ page.next.title }}" class="next">Next &rarr;</a>
+          {% endif %}
+        </nav>
 <!-- End Content -->
       </main>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
-{% for post in site.posts offset: 0 limit: 10 %}
+{% for post in paginator.posts %}
 {% include post.html %}
 {% endfor %}
+{% include pagination.html %}

--- a/styles.css
+++ b/styles.css
@@ -202,6 +202,32 @@ blockquote.twitter-tweet a[href^="https://twitter.com"] {
   font-size: 12px;
 }
 
+nav.pagination {
+  margin: 0 0 2em;
+  overflow: hidden;
+}
+
+nav.pagination a {
+  border-bottom: 0.2rem solid #cc0000;
+  color: #cc0000;
+  font-weight: bold;
+  padding-bottom: 0.1rem;
+  text-decoration: none;
+}
+
+nav.pagination a:hover {
+  border-bottom: 0.2rem solid #000000;
+  color: #000000;
+}
+
+nav.pagination .previous {
+  float: left;
+}
+
+nav.pagination .next {
+  float: right;
+}
+
 @media only screen and (max-width: 640px) {
   nav {
     margin: 2rem 2rem 3rem;


### PR DESCRIPTION
Pagination was removed in a2e2d34 for performance reasons which seem to have been fixed in later versions of Jekyll.