### PR TITLE
Use rails versions on release announcement draft

### DIFF
--- a/_posts/2015-03-02-Rails-4-2-1-rc3-and-4-1-10-rc3-have-been-released.markdown
+++ b/_posts/2015-03-02-Rails-4-2-1-rc3-and-4-1-10-rc3-have-been-released.markdown
@@ -53,7 +53,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.0...v4.2.1.rc3).
 
-## SHA-256
+## Rails 4.2.1.rc3 and 4.1.10.rc3 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2015-03-12-Rails-4-2-1-rc4-and-4-1-10-rc4-have-been-released.markdown
+++ b/_posts/2015-03-12-Rails-4-2-1-rc4-and-4-1-10-rc4-have-been-released.markdown
@@ -53,7 +53,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.0...v4.2.1.rc4).
 
-## SHA-256
+## Rails 4.2.1.rc4 and 4.1.10.rc4 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2015-03-19-Rails-4-2-1-and-4-1-10-have-been-released.markdown
+++ b/_posts/2015-03-19-Rails-4-2-1-and-4-1-10-have-been-released.markdown
@@ -47,7 +47,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.0...v4.2.1).
 
-## SHA-256
+## Rails 4.2.1 and 4.1.10 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-02-24-Rails-5-0-2-rc1-has-been-released.markdown
+++ b/_posts/2017-02-24-Rails-5-0-2-rc1-has-been-released.markdown
@@ -34,7 +34,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.0.1...v5.0.2.rc1).
 
-## SHA-256
+## Rails 5.0.2.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-03-01-Rails-5-0-2-has-been-released.markdown
+++ b/_posts/2017-03-01-Rails-5-0-2-has-been-released.markdown
@@ -30,7 +30,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.0.1...v5.0.2).
 
-## SHA-256
+## Rails 5.0.2 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-13-Rails-4-2-9-rc1-has-been-released-.markdown
+++ b/_posts/2017-06-13-Rails-4-2-9-rc1-has-been-released-.markdown
@@ -35,7 +35,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.8...v4.2.9.rc1).
 
-## SHA-256
+## Rails 4.2.9.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-14-Rails-5-0-4-rc1-has-been-released.markdown
+++ b/_posts/2017-06-14-Rails-5-0-4-rc1-has-been-released.markdown
@@ -33,7 +33,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.0.3...v5.0.4.rc1).
 
-## SHA-256
+## Rails 5.0.4.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-19-Rails-4-2-9-rc2-has-been-released.markdown
+++ b/_posts/2017-06-19-Rails-4-2-9-rc2-has-been-released.markdown
@@ -34,7 +34,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.8...v4.2.9.rc2).
 
-## SHA-256
+## Rails 4.2.9.rc2 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-19-Rails-5-0-4-has-been-released.markdown
+++ b/_posts/2017-06-19-Rails-5-0-4-has-been-released.markdown
@@ -29,7 +29,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.0.3...v5.0.4).
 
-## SHA-256
+## Rails 5.0.4 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-20-Rails-5-1-2-rc1-has-been-released.markdown
+++ b/_posts/2017-06-20-Rails-5-1-2-rc1-has-been-released.markdown
@@ -33,7 +33,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.1...v5.1.2.rc1).
 
-## SHA-256
+## Rails 5.1.2.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-26-Rails-4-2-9-has-been-released.markdown
+++ b/_posts/2017-06-26-Rails-4-2-9-has-been-released.markdown
@@ -31,7 +31,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.8...v4.2.9).
 
-## SHA-256
+## Rails 4.2.9 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-06-26-Rails-5-1-2-has-been-released.markdown
+++ b/_posts/2017-06-26-Rails-5-1-2-has-been-released.markdown
@@ -29,7 +29,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.1...v5.1.2).
 
-## SHA-256
+## Rails 5.1.2 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-07-19-Rails-5-1-3-rc1-and-5-0-5-rc1-released.markdown
+++ b/_posts/2017-07-19-Rails-5-1-3-rc1-and-5-0-5-rc1-released.markdown
@@ -34,7 +34,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.2...v5.1.3.rc1).
 
-## SHA-256
+## Rails 5.1.3.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.
@@ -75,7 +75,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.0.4...v5.0.5.rc1).
 
-## SHA-256
+## Rails 5.0.5.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-07-25-Rails-5-0-5-rc2-and-5-1-3-rc2-have-been-released.markdown
+++ b/_posts/2017-07-25-Rails-5-0-5-rc2-and-5-1-3-rc2-have-been-released.markdown
@@ -53,7 +53,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.2...v5.1.3.rc2).
 
-## SHA-256
+## Rails 5.0.5.rc2 and 5.1.3.rc2 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-07-31-Rails-5-0-5-and-5-1-3-rc3-released.markdown
+++ b/_posts/2017-07-31-Rails-5-0-5-and-5-1-3-rc3-released.markdown
@@ -52,7 +52,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.2...v5.1.3.rc3).
 
-## SHA-256
+## Rails 5.0.5 and 5.1.3.rc3 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-08-03-Rails-5-1-3-released.markdown
+++ b/_posts/2017-08-03-Rails-5-1-3-released.markdown
@@ -29,7 +29,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.2...v5.1.3).
 
-## SHA-256
+## Rails 5.1.3 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-08-24-Rails-5-1-4-rc1-and-5-0-6-rc1-released.markdown
+++ b/_posts/2017-08-24-Rails-5-1-4-rc1-and-5-0-6-rc1-released.markdown
@@ -53,7 +53,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.3...v5.1.4.rc1).
   
-## SHA-256
+## Rails 5.1.4.rc1 and 5.0.6.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-09-07-Rails-5-1-4-and-5-0-6-released.markdown
+++ b/_posts/2017-09-07-Rails-5-1-4-and-5-0-6-released.markdown
@@ -50,7 +50,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.3...v5.1.4).
 
-## SHA-256
+## Rails 5.1.4 and 5.0.6 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-09-20-Rails-4-2-10-rc1-released.markdown
+++ b/_posts/2017-09-20-Rails-4-2-10-rc1-released.markdown
@@ -31,7 +31,7 @@ The remaining gems (Action Mailer, Action View, Active Job, Active Model, Active
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.9...v4.2.10.rc1).
 
-## SHA-256
+## Rails 4.2.10.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2017-09-27-Rails-4-2-10-released.markdown
+++ b/_posts/2017-09-27-Rails-4-2-10-released.markdown
@@ -37,7 +37,7 @@ The remaining gems (Action Mailer, Action View, Active Job, Active Model, Active
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v4.2.9...v4.2.10).
 
-## SHA-256
+## Rails 4.2.10 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-02-01-Rails-5-1-5-rc1-has-been-released-.markdown
+++ b/_posts/2018-02-01-Rails-5-1-5-rc1-has-been-released-.markdown
@@ -33,7 +33,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.4...v5.1.5.rc1).
 
-## SHA-256
+## Rails 5.1.5.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-02-14-Rails-5-1-5-has-been-released.markdown
+++ b/_posts/2018-02-14-Rails-5-1-5-has-been-released.markdown
@@ -30,7 +30,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.4...v5.1.5).
 
-## SHA-256
+## Rails 5.1.5 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-03-29-Rails-5-0-7-and-5-1-6-have-been-released.markdown
+++ b/_posts/2018-03-29-Rails-5-0-7-and-5-1-6-have-been-released.markdown
@@ -49,7 +49,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.5...v5.1.6).
   
-## SHA-256
+## Rails 5.0.7 and 5.1.6 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-07-30-Rails-5-2-1-rc1-has-been-released-.markdown
+++ b/_posts/2018-07-30-Rails-5-2-1-rc1-has-been-released-.markdown
@@ -34,7 +34,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.0...v5.2.1.rc1).
 
-## SHA-256
+## Rails 5.2.1.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-08-07-Rails-5-2-1-has-been-released-.markdown
+++ b/_posts/2018-08-07-Rails-5-2-1-has-been-released-.markdown
@@ -31,7 +31,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.0...v5.2.1).
 
-## SHA-256
+## Rails 5.2.1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-11-27-Rails-4-2-5-0-5-1-5-2-have-been-released.markdown
+++ b/_posts/2018-11-27-Rails-4-2-5-0-5-1-5-2-have-been-released.markdown
@@ -32,7 +32,7 @@ Again, as always, if you run in to any bugs, please file them on the Rails issue
 If you run in to security issues, please follow the reporting process which can be found
 [here](http://rubyonrails.org/security/).
 
-## SHA-256
+## Rails 4.2.11, 5.0.7.1, 5.1.6.1 and 5.2.1.1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-11-28-Rails-5-2-2-rc1-has-been-released.markdown
+++ b/_posts/2018-11-28-Rails-5-2-2-rc1-has-been-released.markdown
@@ -35,7 +35,7 @@ To view the changes for each gem, please read the changelogs on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.1...v5.2.2.rc1).
 
-## SHA-256
+## Rails 5.2.2.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2018-12-04-Rails-5-2-2-has-been-released-.markdown
+++ b/_posts/2018-12-04-Rails-5-2-2-has-been-released-.markdown
@@ -36,7 +36,7 @@ To see a summary of changes, please read the release on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.1...v5.2.2).
 
-## SHA-256
+## Rails 5.2.2 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2019-03-13-Rails-4-2-5-1-5-1-6-2-have-been-released.markdown
+++ b/_posts/2019-03-13-Rails-4-2-5-1-5-1-6-2-have-been-released.markdown
@@ -34,7 +34,7 @@ We've done our best to minimize any impact to your applications, but if you run 
 If you run in to security issues, please follow the reporting process which can be found
 [here](http://rubyonrails.org/security/).
 
-## SHA-256
+## Rails 4.2.11.1, 5.0.7.2, 5.1.6.2, 5.2.2.1, and 6.0.0.beta3 SHA-256
 
 If you'd like to verify that your gem is the same as the one we've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2019-03-21-Rails-5-2-3-rc1-has-been-released-.markdown
+++ b/_posts/2019-03-21-Rails-5-2-3-rc1-has-been-released-.markdown
@@ -14,7 +14,7 @@ If no regressions are found, expect the final release on Wednesday, March 27, 20
 If you find one, please open an [issue on GitHub](https://github.com/rails/rails/issues/new)
 and mention me (@rafaelfranca) on it, so that we can fix it before the final release.
 
-## CHANGES since 5.2.2
+## CHANGES since 5.2.2 (rc1)
 
 To view the changes for each gem, please read the changelogs on GitHub:
 * [Action Cable CHANGELOG](https://github.com/rails/rails/blob/v5.2.3.rc1/actioncable/CHANGELOG.md)
@@ -37,7 +37,7 @@ To see a summary of changes, please read the release on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.2...v5.2.3.rc1).
 
-## SHA-256
+## Rails 5.2.3.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2019-03-22-Rails-5-1-7-rc1-has-been-released-.markdown
+++ b/_posts/2019-03-22-Rails-5-1-7-rc1-has-been-released-.markdown
@@ -19,7 +19,7 @@ and mention me (@rafaelfranca) on it, so that we can fix it before the final rel
 
 
 
-## CHANGES since 5.1.6
+## CHANGES since 5.1.6 (rc1)
 
 To view the changes for each gem, please read the changelogs on GitHub:
 * [Action Cable CHANGELOG](https://github.com/rails/rails/blob/v5.1.7.rc1/actioncable/CHANGELOG.md)
@@ -41,7 +41,7 @@ To see a summary of changes, please read the release on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.6...v5.1.7.rc1).
 
-## SHA-256
+## Rails 5.1.7.rc1 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2019-03-27-Rails-5-1-7-has-been-released.markdown
+++ b/_posts/2019-03-27-Rails-5-1-7-has-been-released.markdown
@@ -33,7 +33,7 @@ To see a summary of changes, please read the release on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.1.6...v5.1.7).
 
-## SHA-256
+## Rails 5.1.7 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.

--- a/_posts/2019-03-27-Rails-5-2-3-has-been-released.markdown
+++ b/_posts/2019-03-27-Rails-5-2-3-has-been-released.markdown
@@ -34,7 +34,7 @@ To see a summary of changes, please read the release on GitHub:
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v5.2.2...v5.2.3).
 
-## SHA-256
+## Rails 5.2.3 SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.


### PR DESCRIPTION
This allow to have uniq link anchor for each version sha256 and
fix markup errors that does not allow same id on same page

ref https://github.com/rails/rails/pull/36541